### PR TITLE
Master to Main 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,15 @@ This module creates an EC2 instance in AWS with configurable options for AMI, in
 
 ```hcl
 module "ec2_instance" {
-  source = "git::https://github.com/amaan-igs/terraform-aws-ec2-instance.git"
+  source = "sudo-terraform-aws-modules/ec2-instance/aws"
 
-  ami_id                = "ami-00bb6a80f01f03502"
-  instance_type         = "t2.micro"
-  subnet_id             = "subnet-0194c32a03d44fdbd"
-  security_group_ids    = ["sg-07ea31bd8b8dab9f1"]
-  instance_name         = "prod-sample"
-  key_name              = "sample-key" # Ensure the key exists in AWS
-  iam_instance_profile  = "sample-instance-profile"
-  root_volume_size      = 10
-  root_volume_type      = "gp3"
-  root_volume_encryption = true
-  enable_imdsv2         = true
+  name = "single-instance"
 
-  ebs_volumes = [
-    {
-      device_name = "/dev/xvdf"
-      volume_size = 30
-      volume_type = "gp3"
-      encrypted   = true
-    }
-  ]
+  instance_type          = "t2.micro"
+  key_name               = "user1"
+  monitoring             = true
+  vpc_security_group_ids = ["sg-12345678"]
+  subnet_id              = "subnet-eddcdzz4"
 
   tags = {
     Environment = "production"
@@ -42,39 +29,110 @@ module "ec2_instance" {
 
 ## Inputs
 
-| Name                  | Description                                                  | Type            | Default   | Required |
-|-----------------------|--------------------------------------------------------------|----------------|----------|----------|
-| `ami_id`             | The AMI ID to use for the EC2 instance.                      | `string`        | -        | Yes      |
-| `instance_type`      | The type of instance to start.                               | `string`        | `t2.micro` | No      |
-| `subnet_id`          | The VPC Subnet ID to launch the instance in.                 | `string`        | -        | Yes      |
-| `security_group_ids` | A list of security group IDs to associate with the instance. | `list(string)`  | -        | Yes      |
-| `key_name`           | The key name of the Key Pair to use for the instance.        | `string`        | `""`     | No       |
-| `instance_name`      | The name tag for the EC2 instance.                           | `string`        | -        | Yes      |
-| `root_volume_size`   | The size of the root volume in gigabytes.                    | `number`        | `8`      | No       |
-| `root_volume_type`   | The type of the root volume (e.g., gp2, gp3).                | `string`        | `gp2`    | No       |
-| `root_volume_encryption` | Enable encryption for the root volume.                   | `bool`          | `true`   | No       |
-| `tags`              | A map of tags to assign to the instance.                      | `map(string)`   | `{}`     | No       |
-| `iam_instance_profile` | The IAM instance profile to attach to the EC2 instance.    | `string`        | `""`     | No       |
-| `ebs_volumes`       | A list of additional EBS volumes to attach to the instance.  | `list(object)`  | `[]`     | No       |
-| `enable_imdsv2`     | Enable IMDSv2 for the EC2 instance.                           | `bool`          | `true`   | No       |
----
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ami"></a> [ami](#input\_ami) | ID of AMI to use for the instance | `string` | `null` | no |
+| <a name="input_ami_ssm_parameter"></a> [ami\_ssm\_parameter](#input\_ami\_ssm\_parameter) | SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html) | `string` | `"/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"` | no |
+| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a public IP address with an instance in a VPC | `bool` | `null` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
+| <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
+| <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance | `number` | `null` | no |
+| <a name="input_cpu_credits"></a> [cpu\_credits](#input\_cpu\_credits) | The credit option for CPU usage (unlimited or standard) | `string` | `null` | no |
+| <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Defines CPU options to apply to the instance at launch time. | `any` | `{}` | no |
+| <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set) | `number` | `null` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create an instance | `bool` | `true` | no |
+| <a name="input_create_eip"></a> [create\_eip](#input\_create\_eip) | Determines whether a public EIP will be created and associated with the instance. | `bool` | `false` | no |
+| <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `false` | no |
+| <a name="input_create_spot_instance"></a> [create\_spot\_instance](#input\_create\_spot\_instance) | Depicts if the instance is a spot instance | `bool` | `false` | no |
+| <a name="input_disable_api_stop"></a> [disable\_api\_stop](#input\_disable\_api\_stop) | If true, enables EC2 Instance Stop Protection | `bool` | `null` | no |
+| <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 Instance Termination Protection | `bool` | `null` | no |
+| <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(any)` | `[]` | no |
+| <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |
+| <a name="input_eip_domain"></a> [eip\_domain](#input\_eip\_domain) | Indicates if this EIP is for use in VPC | `string` | `"vpc"` | no |
+| <a name="input_eip_tags"></a> [eip\_tags](#input\_eip\_tags) | A map of additional tags to add to the eip | `map(string)` | `{}` | no |
+| <a name="input_enable_volume_tags"></a> [enable\_volume\_tags](#input\_enable\_volume\_tags) | Whether to enable volume tags (if enabled it conflicts with root\_block\_device tags) | `bool` | `true` | no |
+| <a name="input_enclave_options_enabled"></a> [enclave\_options\_enabled](#input\_enclave\_options\_enabled) | Whether Nitro Enclaves will be enabled on the instance. Defaults to `false` | `bool` | `null` | no |
+| <a name="input_ephemeral_block_device"></a> [ephemeral\_block\_device](#input\_ephemeral\_block\_device) | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
+| <a name="input_get_password_data"></a> [get\_password\_data](#input\_get\_password\_data) | If true, wait for password data to become available and retrieve it | `bool` | `null` | no |
+| <a name="input_hibernation"></a> [hibernation](#input\_hibernation) | If true, the launched EC2 instance will support hibernation | `bool` | `null` | no |
+| <a name="input_host_id"></a> [host\_id](#input\_host\_id) | ID of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host | `string` | `null` | no |
+| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | `null` | no |
+| <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | Description of the role | `string` | `null` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `null` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role path | `string` | `null` | no |
+| <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
+| <a name="input_iam_role_policies"></a> [iam\_role\_policies](#input\_iam\_role\_policies) | Policies attached to the IAM role | `map(string)` | `{}` | no |
+| <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |
+| <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name` or `name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_ignore_ami_changes"></a> [ignore\_ami\_changes](#input\_ignore\_ami\_changes) | Whether changes to the AMI ID changes should be ignored by Terraform. Note - changing this value will result in the replacement of the instance | `bool` | `false` | no |
+| <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance | `string` | `null` | no |
+| <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags for the instance | `map(string)` | `{}` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to start | `string` | `"t3.micro"` | no |
+| <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `null` | no |
+| <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
+| <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template | `map(string)` | `{}` | no |
+| <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
+| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options of the instance | `map(string)` | <pre>{<br/>  "http_endpoint": "enabled",<br/>  "http_put_response_hop_limit": 1,<br/>  "http_tokens": "required"<br/>}</pre> | no |
+| <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name to be used on EC2 instance created | `string` | `""` | no |
+| <a name="input_network_interface"></a> [network\_interface](#input\_network\_interface) | Customize network interfaces to be attached at instance boot time | `list(map(string))` | `[]` | no |
+| <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The Placement Group to start the instance in | `string` | `null` | no |
+| <a name="input_private_dns_name_options"></a> [private\_dns\_name\_options](#input\_private\_dns\_name\_options) | Customize the private DNS name options of the instance | `map(string)` | `{}` | no |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Private IP address to associate with the instance in a VPC | `string` | `null` | no |
+| <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | Customize details about the root block device of the instance. See Block Devices below for details | `list(any)` | `[]` | no |
+| <a name="input_secondary_private_ips"></a> [secondary\_private\_ips](#input\_secondary\_private\_ips) | A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e. referenced in a `network_interface block` | `list(string)` | `null` | no |
+| <a name="input_source_dest_check"></a> [source\_dest\_check](#input\_source\_dest\_check) | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs | `bool` | `null` | no |
+| <a name="input_spot_block_duration_minutes"></a> [spot\_block\_duration\_minutes](#input\_spot\_block\_duration\_minutes) | The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360) | `number` | `null` | no |
+| <a name="input_spot_instance_interruption_behavior"></a> [spot\_instance\_interruption\_behavior](#input\_spot\_instance\_interruption\_behavior) | Indicates Spot instance behavior when it is interrupted. Valid values are `terminate`, `stop`, or `hibernate` | `string` | `null` | no |
+| <a name="input_spot_launch_group"></a> [spot\_launch\_group](#input\_spot\_launch\_group) | A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually | `string` | `null` | no |
+| <a name="input_spot_price"></a> [spot\_price](#input\_spot\_price) | The maximum price to request on the spot market. Defaults to on-demand price | `string` | `null` | no |
+| <a name="input_spot_type"></a> [spot\_type](#input\_spot\_type) | If set to one-time, after the instance is terminated, the spot request will be closed. Default `persistent` | `string` | `null` | no |
+| <a name="input_spot_valid_from"></a> [spot\_valid\_from](#input\_spot\_valid\_from) | The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ) | `string` | `null` | no |
+| <a name="input_spot_valid_until"></a> [spot\_valid\_until](#input\_spot\_valid\_until) | The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ) | `string` | `null` | no |
+| <a name="input_spot_wait_for_fulfillment"></a> [spot\_wait\_for\_fulfillment](#input\_spot\_wait\_for\_fulfillment) | If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached | `bool` | `null` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_tenancy"></a> [tenancy](#input\_tenancy) | The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host | `string` | `null` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting EC2 instance resources | `map(string)` | `{}` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user\_data\_base64 instead | `string` | `null` | no |
+| <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | Can be used instead of user\_data to pass base64-encoded binary data directly. Use this instead of user\_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption | `string` | `null` | no |
+| <a name="input_user_data_replace_on_change"></a> [user\_data\_replace\_on\_change](#input\_user\_data\_replace\_on\_change) | When used in combination with user\_data or user\_data\_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set | `bool` | `null` | no |
+| <a name="input_volume_tags"></a> [volume\_tags](#input\_volume\_tags) | A mapping of tags to assign to the devices created by the instance at launch time | `map(string)` | `{}` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of security group IDs to associate with | `list(string)` | `null` | no |
 
 ## Outputs
 
-| Name                   | Description                                          | Value                                       |
-|------------------------|------------------------------------------------------|---------------------------------------------|
-| `instance_id`         | The ID of the EC2 instance.                          | `aws_instance.ec2_instance.id`             |
-| `public_ip`          | The public IP address of the EC2 instance.           | `aws_instance.ec2_instance.public_ip`      |
-| `private_ip`         | The private IP address of the EC2 instance.          | `aws_instance.ec2_instance.private_ip`     |
-| `instance_arn`       | The ARN of the EC2 instance.                         | `aws_instance.ec2_instance.arn`            |
-| `iam_instance_profile` | The IAM instance profile attached to the instance. | `aws_instance.ec2_instance.iam_instance_profile` |
-| `instance_name`      | The name tag assigned to the EC2 instance.           | `aws_instance.ec2_instance.tags["Name"]`   |
-| `instance_type`      | The type of the EC2 instance.                        | `aws_instance.ec2_instance.instance_type`  |
-| `key_name`          | The key pair name assigned to the EC2 instance.      | `aws_instance.ec2_instance.key_name`       |
-| `root_volume_size`  | The size of the root volume in GB.                    | `aws_instance.ec2_instance.root_block_device[0].volume_size` |
-| `ebs_volumes`       | The additional EBS volumes attached to the instance.  | `aws_instance.ec2_instance.ebs_block_device` |
-| `tags`              | The tags associated with the EC2 instance.            | `aws_instance.ec2_instance.tags`           |
----
+| Name | Description |
+|------|-------------|
+| <a name="output_ami"></a> [ami](#output\_ami) | AMI ID that was used to create the instance |
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the instance |
+| <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | The availability zone of the created instance |
+| <a name="output_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#output\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
+| <a name="output_ebs_block_device"></a> [ebs\_block\_device](#output\_ebs\_block\_device) | EBS block device information |
+| <a name="output_ephemeral_block_device"></a> [ephemeral\_block\_device](#output\_ephemeral\_block\_device) | Ephemeral block device information |
+| <a name="output_iam_instance_profile_arn"></a> [iam\_instance\_profile\_arn](#output\_iam\_instance\_profile\_arn) | ARN assigned by AWS to the instance profile |
+| <a name="output_iam_instance_profile_id"></a> [iam\_instance\_profile\_id](#output\_iam\_instance\_profile\_id) | Instance profile's ID |
+| <a name="output_iam_instance_profile_unique"></a> [iam\_instance\_profile\_unique](#output\_iam\_instance\_profile\_unique) | Stable and unique string identifying the IAM instance profile |
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The name of the IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the instance |
+| <a name="output_instance_state"></a> [instance\_state](#output\_instance\_state) | The state of the instance |
+| <a name="output_ipv6_addresses"></a> [ipv6\_addresses](#output\_ipv6\_addresses) | The IPv6 address assigned to the instance, if applicable |
+| <a name="output_outpost_arn"></a> [outpost\_arn](#output\_outpost\_arn) | The ARN of the Outpost the instance is assigned to |
+| <a name="output_password_data"></a> [password\_data](#output\_password\_data) | Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true |
+| <a name="output_primary_network_interface_id"></a> [primary\_network\_interface\_id](#output\_primary\_network\_interface\_id) | The ID of the instance's primary network interface |
+| <a name="output_private_dns"></a> [private\_dns](#output\_private\_dns) | The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | The private IP address assigned to the instance |
+| <a name="output_public_dns"></a> [public\_dns](#output\_public\_dns) | The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | The public IP address assigned to the instance, if applicable. |
+| <a name="output_root_block_device"></a> [root\_block\_device](#output\_root\_block\_device) | Root block device information |
+| <a name="output_spot_bid_status"></a> [spot\_bid\_status](#output\_spot\_bid\_status) | The current bid status of the Spot Instance Request |
+| <a name="output_spot_instance_id"></a> [spot\_instance\_id](#output\_spot\_instance\_id) | The Instance ID (if any) that is currently fulfilling the Spot Instance request |
+| <a name="output_spot_request_state"></a> [spot\_request\_state](#output\_spot\_request\_state) | The current request state of the Spot Instance Request |
+| <a name="output_tags_all"></a> [tags\_all](#output\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block |
+<!-- END_TF_DOCS -->
 
 ## File Structure Overview 
 

--- a/README.md
+++ b/README.md
@@ -150,3 +150,10 @@ sudo-terraform-ec2-instance/
 ├── variables.tf               # Definitions of module input variables
 └── versions.tf                # Terraform and provider version constraints
 ```
+## Authors
+
+Module is maintained by [Amaan Ul Haq Siddiqui](https://github.com/amaan-igs) & [Hameedullah Khan](https://github.com/hameedullah).
+
+## License
+
+Apache 2 Licensed. See [LICENSE](https://github.com/sudo-terraform-aws-modules/terraform-aws-ec2-instance/blob/main/LICENSE) for full details.

--- a/main.tf
+++ b/main.tf
@@ -1,38 +1,612 @@
-resource "aws_instance" "ec2_instance" {
-  ami                    = var.ami_id                                                       # Required
-  instance_type          = var.instance_type                                                # Optional (default: t2.micro)
-  subnet_id              = var.subnet_id                                                    # Required
-  vpc_security_group_ids = var.security_group_ids                                           # Required
-  key_name               = var.key_name                                                     # Optional
-  iam_instance_profile   = var.iam_instance_profile != "" ? var.iam_instance_profile : null # Optional
-  tags                   = merge(var.tags, { Name = var.instance_name })                    # Required (instance_name), Optional (tags)
-  monitoring             = true                                                             #CKV_AWS_126
-  ebs_optimized          = true                                                             #CKV_AWS_135
+data "aws_partition" "current" {}
 
-  # Root volume configuration
-  root_block_device {
-    volume_size = var.root_volume_size
-    volume_type = var.root_volume_type
-    encrypted   = var.root_volume_encryption
-  }
+locals {
+  create = var.create 
 
-  dynamic "ebs_block_device" {
-    for_each = var.ebs_volumes
+  is_t_instance_type = replace(var.instance_type, "/^t(2|3|3a|4g){1}\\..*$/", "1") == "1" ? true : false
+
+  ami = try(coalesce(var.ami, try(nonsensitive(data.aws_ssm_parameter.this[0].value), null)), null)
+}
+
+data "aws_ssm_parameter" "this" {
+  count = local.create && var.ami == null ? 1 : 0
+
+  name = var.ami_ssm_parameter
+}
+
+# Instance
+
+resource "aws_instance" "this" {
+  count = local.create && !var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
+
+  ami                  = local.ami
+  instance_type        = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
+  hibernation          = var.hibernation
+
+  user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
+  user_data_replace_on_change = var.user_data_replace_on_change
+
+  availability_zone      = var.availability_zone
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  key_name             = var.key_name
+  monitoring           = var.monitoring
+  get_password_data    = var.get_password_data
+  iam_instance_profile = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].name : var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
     content {
-      device_name = ebs_block_device.value.device_name
-      volume_size = ebs_block_device.value.volume_size
-      volume_type = ebs_block_device.value.volume_type
-      encrypted   = ebs_block_device.value.encrypted
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
     }
   }
 
-  # IMDSv2 configuration
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = var.enable_imdsv2 ? "required" : "optional" # Optional (default: required)
+  dynamic "capacity_reservation_specification" {
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
+
+    content {
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
+
+      dynamic "capacity_reservation_target" {
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
+
+        content {
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
+        }
+      }
+    }
   }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+
+    content {
+      delete_on_termination = try(root_block_device.value.delete_on_termination, null)
+      encrypted             = try(root_block_device.value.encrypted, null)
+      iops                  = try(root_block_device.value.iops, null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      tags                  = try(root_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+
+    content {
+      delete_on_termination = try(ebs_block_device.value.delete_on_termination, null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = try(ebs_block_device.value.encrypted, null)
+      iops                  = try(ebs_block_device.value.iops, null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = try(ebs_block_device.value.volume_size, null)
+      volume_type           = try(ebs_block_device.value.volume_type, null)
+      throughput            = try(ebs_block_device.value.throughput, null)
+      tags                  = try(ebs_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = try(ephemeral_block_device.value.no_device, null)
+      virtual_name = try(ephemeral_block_device.value.virtual_name, null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, "enabled")
+      http_tokens                 = try(metadata_options.value.http_tokens, "required")
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, 1)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = try(network_interface.value.delete_on_termination, false)
+    }
+  }
+
+  dynamic "private_dns_name_options" {
+    for_each = length(var.private_dns_name_options) > 0 ? [var.private_dns_name_options] : []
+
+    content {
+      hostname_type                        = try(private_dns_name_options.value.hostname_type, null)
+      enable_resource_name_dns_a_record    = try(private_dns_name_options.value.enable_resource_name_dns_a_record, null)
+      enable_resource_name_dns_aaaa_record = try(private_dns_name_options.value.enable_resource_name_dns_aaaa_record, null)
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = length(var.launch_template) > 0 ? [var.launch_template] : []
+
+    content {
+      id      = lookup(var.launch_template, "id", null)
+      name    = lookup(var.launch_template, "name", null)
+      version = lookup(var.launch_template, "version", null)
+    }
+  }
+
+  dynamic "maintenance_options" {
+    for_each = length(var.maintenance_options) > 0 ? [var.maintenance_options] : []
+
+    content {
+      auto_recovery = try(maintenance_options.value.auto_recovery, null)
+    }
+  }
+
+  enclave_options {
+    enabled = var.enclave_options_enabled
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  disable_api_stop                     = var.disable_api_stop
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+  host_id                              = var.host_id
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    update = try(var.timeouts.update, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
+  tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+  volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+}
+
+# Instance - Ignore AMI Changes
+
+resource "aws_instance" "ignore_ami" {
+  count = local.create && var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
+
+  ami                  = local.ami
+  instance_type        = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
+  hibernation          = var.hibernation
+
+  user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
+  user_data_replace_on_change = var.user_data_replace_on_change
+
+  availability_zone      = var.availability_zone
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  key_name             = var.key_name
+  monitoring           = var.monitoring
+  get_password_data    = var.get_password_data
+  iam_instance_profile = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].name : var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
+
+    content {
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
+
+      dynamic "capacity_reservation_target" {
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
+
+        content {
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
+        }
+      }
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+
+    content {
+      delete_on_termination = try(root_block_device.value.delete_on_termination, null)
+      encrypted             = try(root_block_device.value.encrypted, null)
+      iops                  = try(root_block_device.value.iops, null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      tags                  = try(root_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+
+    content {
+      delete_on_termination = try(ebs_block_device.value.delete_on_termination, null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = try(ebs_block_device.value.encrypted, null)
+      iops                  = try(ebs_block_device.value.iops, null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = try(ebs_block_device.value.volume_size, null)
+      volume_type           = try(ebs_block_device.value.volume_type, null)
+      throughput            = try(ebs_block_device.value.throughput, null)
+      tags                  = try(ebs_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = try(ephemeral_block_device.value.no_device, null)
+      virtual_name = try(ephemeral_block_device.value.virtual_name, null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, "enabled")
+      http_tokens                 = try(metadata_options.value.http_tokens, "required")
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, 1)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = try(network_interface.value.delete_on_termination, false)
+    }
+  }
+
+  dynamic "private_dns_name_options" {
+    for_each = length(var.private_dns_name_options) > 0 ? [var.private_dns_name_options] : []
+
+    content {
+      hostname_type                        = try(private_dns_name_options.value.hostname_type, null)
+      enable_resource_name_dns_a_record    = try(private_dns_name_options.value.enable_resource_name_dns_a_record, null)
+      enable_resource_name_dns_aaaa_record = try(private_dns_name_options.value.enable_resource_name_dns_aaaa_record, null)
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = length(var.launch_template) > 0 ? [var.launch_template] : []
+
+    content {
+      id      = lookup(var.launch_template, "id", null)
+      name    = lookup(var.launch_template, "name", null)
+      version = lookup(var.launch_template, "version", null)
+    }
+  }
+
+  dynamic "maintenance_options" {
+    for_each = length(var.maintenance_options) > 0 ? [var.maintenance_options] : []
+
+    content {
+      auto_recovery = try(maintenance_options.value.auto_recovery, null)
+    }
+  }
+
+  enclave_options {
+    enabled = var.enclave_options_enabled
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  disable_api_stop                     = var.disable_api_stop
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+  host_id                              = var.host_id
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    update = try(var.timeouts.update, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
+  tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+  volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+
+  lifecycle {
+    ignore_changes = [
+      ami
+    ]
+  }
+}
+
+# Spot Instance
+
+resource "aws_spot_instance_request" "this" {
+  count = local.create && var.create_spot_instance ? 1 : 0
+
+  ami                  = local.ami
+  instance_type        = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
+  hibernation          = var.hibernation
+
+  user_data                   = var.user_data
+  user_data_base64            = var.user_data_base64
+  user_data_replace_on_change = var.user_data_replace_on_change
+
+  availability_zone      = var.availability_zone
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  key_name             = var.key_name
+  monitoring           = var.monitoring
+  get_password_data    = var.get_password_data
+  iam_instance_profile = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].name : var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  secondary_private_ips       = var.secondary_private_ips
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  # Spot request specific attributes
+  spot_price                     = var.spot_price
+  wait_for_fulfillment           = var.spot_wait_for_fulfillment
+  spot_type                      = var.spot_type
+  launch_group                   = var.spot_launch_group
+  block_duration_minutes         = var.spot_block_duration_minutes
+  instance_interruption_behavior = var.spot_instance_interruption_behavior
+  valid_until                    = var.spot_valid_until
+  valid_from                     = var.spot_valid_from
+  # End spot request specific attributes
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
+
+  dynamic "capacity_reservation_specification" {
+    for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
+
+    content {
+      capacity_reservation_preference = try(capacity_reservation_specification.value.capacity_reservation_preference, null)
+
+      dynamic "capacity_reservation_target" {
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
+        content {
+          capacity_reservation_id                 = try(capacity_reservation_target.value.capacity_reservation_id, null)
+          capacity_reservation_resource_group_arn = try(capacity_reservation_target.value.capacity_reservation_resource_group_arn, null)
+        }
+      }
+    }
+  }
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+
+    content {
+      delete_on_termination = try(root_block_device.value.delete_on_termination, null)
+      encrypted             = try(root_block_device.value.encrypted, null)
+      iops                  = try(root_block_device.value.iops, null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      tags                  = try(root_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+
+    content {
+      delete_on_termination = try(ebs_block_device.value.delete_on_termination, null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = try(ebs_block_device.value.encrypted, null)
+      iops                  = try(ebs_block_device.value.iops, null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = try(ebs_block_device.value.volume_size, null)
+      volume_type           = try(ebs_block_device.value.volume_type, null)
+      throughput            = try(ebs_block_device.value.throughput, null)
+      tags                  = try(ebs_block_device.value.tags, null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = try(ephemeral_block_device.value.no_device, null)
+      virtual_name = try(ephemeral_block_device.value.virtual_name, null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(var.metadata_options) > 0 ? [var.metadata_options] : []
+
+    content {
+      http_endpoint               = try(metadata_options.value.http_endpoint, "enabled")
+      http_tokens                 = try(metadata_options.value.http_tokens, "required")
+      http_put_response_hop_limit = try(metadata_options.value.http_put_response_hop_limit, 1)
+      instance_metadata_tags      = try(metadata_options.value.instance_metadata_tags, null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = try(network_interface.value.delete_on_termination, false)
+    }
+  }
+
+  dynamic "launch_template" {
+    for_each = length(var.launch_template) > 0 ? [var.launch_template] : []
+
+    content {
+      id      = lookup(var.launch_template, "id", null)
+      name    = lookup(var.launch_template, "name", null)
+      version = lookup(var.launch_template, "version", null)
+    }
+  }
+
+  enclave_options {
+    enabled = var.enclave_options_enabled
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+  host_id                              = var.host_id
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  timeouts {
+    create = try(var.timeouts.create, null)
+    delete = try(var.timeouts.delete, null)
+  }
+
+  tags        = merge({ "Name" = var.name }, var.instance_tags, var.tags)
+  volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
+}
+
+# IAM Role / Instance Profile
+
+locals {
+  iam_role_name = try(coalesce(var.iam_role_name, var.name), "")
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  statement {
+    sid     = "EC2AssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+  description = var.iam_role_description
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role_policy[0].json
+  permissions_boundary  = var.iam_role_permissions_boundary
+  force_detach_policies = true
+
+  tags = merge(var.tags, var.iam_role_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = { for k, v in var.iam_role_policies : k => v if var.create && var.create_iam_instance_profile }
+
+  policy_arn = each.value
+  role       = aws_iam_role.this[0].name
+}
+
+resource "aws_iam_instance_profile" "this" {
+  count = var.create && var.create_iam_instance_profile ? 1 : 0
+
+  role = aws_iam_role.this[0].name
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+
+  tags = merge(var.tags, var.iam_role_tags)
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# Elastic IP
+
+resource "aws_eip" "this" {
+  count = local.create && var.create_eip && !var.create_spot_instance ? 1 : 0
+
+  instance = try(
+    aws_instance.this[0].id,
+    aws_instance.ignore_ami[0].id,
+  )
+
+  domain = var.eip_domain
+
+  tags = merge(var.tags, var.eip_tags)
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_partition" "current" {}
 
 locals {
-  create = var.create 
+  create = var.create
 
   is_t_instance_type = replace(var.instance_type, "/^t(2|3|3a|4g){1}\\..*$/", "1") == "1" ? true : false
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,54 +1,228 @@
-output "instance_id" {
-  description = "The ID of the EC2 instance."
-  value       = aws_instance.ec2_instance.id
+output "id" {
+  description = "The ID of the instance"
+  value = try(
+    aws_instance.this[0].id,
+    aws_instance.ignore_ami[0].id,
+    aws_spot_instance_request.this[0].id,
+    null,
+  )
+}
+
+output "arn" {
+  description = "The ARN of the instance"
+  value = try(
+    aws_instance.this[0].arn,
+    aws_instance.ignore_ami[0].arn,
+    aws_spot_instance_request.this[0].arn,
+    null,
+  )
+}
+
+output "capacity_reservation_specification" {
+  description = "Capacity reservation specification of the instance"
+  value = try(
+    aws_instance.this[0].capacity_reservation_specification,
+    aws_instance.ignore_ami[0].capacity_reservation_specification,
+    aws_spot_instance_request.this[0].capacity_reservation_specification,
+    null,
+  )
+}
+
+output "instance_state" {
+  description = "The state of the instance"
+  value = try(
+    aws_instance.this[0].instance_state,
+    aws_instance.ignore_ami[0].instance_state,
+    aws_spot_instance_request.this[0].instance_state,
+    null,
+  )
+}
+
+output "outpost_arn" {
+  description = "The ARN of the Outpost the instance is assigned to"
+  value = try(
+    aws_instance.this[0].outpost_arn,
+    aws_instance.ignore_ami[0].outpost_arn,
+    aws_spot_instance_request.this[0].outpost_arn,
+    null,
+  )
+}
+
+output "password_data" {
+  description = "Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true"
+  value = try(
+    aws_instance.this[0].password_data,
+    aws_instance.ignore_ami[0].password_data,
+    aws_spot_instance_request.this[0].password_data,
+    null,
+  )
+}
+
+output "primary_network_interface_id" {
+  description = "The ID of the instance's primary network interface"
+  value = try(
+    aws_instance.this[0].primary_network_interface_id,
+    aws_instance.ignore_ami[0].primary_network_interface_id,
+    aws_spot_instance_request.this[0].primary_network_interface_id,
+    null,
+  )
+}
+
+output "private_dns" {
+  description = "The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
+  value = try(
+    aws_instance.this[0].private_dns,
+    aws_instance.ignore_ami[0].private_dns,
+    aws_spot_instance_request.this[0].private_dns,
+    null,
+  )
+}
+
+output "public_dns" {
+  description = "The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
+  value = try(
+    aws_instance.this[0].public_dns,
+    aws_instance.ignore_ami[0].public_dns,
+    aws_spot_instance_request.this[0].public_dns,
+    null,
+  )
 }
 
 output "public_ip" {
-  description = "The public IP address of the EC2 instance."
-  value       = aws_instance.ec2_instance.public_ip
+  description = "The public IP address assigned to the instance, if applicable."
+  value = try(
+    aws_eip.this[0].public_ip,
+    aws_instance.this[0].public_ip,
+    aws_instance.ignore_ami[0].public_ip,
+    aws_spot_instance_request.this[0].public_ip,
+    null,
+  )
 }
 
 output "private_ip" {
-  description = "The private IP address of the EC2 instance."
-  value       = aws_instance.ec2_instance.private_ip
+  description = "The private IP address assigned to the instance"
+  value = try(
+    aws_instance.this[0].private_ip,
+    aws_instance.ignore_ami[0].private_ip,
+    aws_spot_instance_request.this[0].private_ip,
+    null,
+  )
 }
 
-output "instance_arn" {
-  description = "The ARN of the EC2 instance."
-  value       = aws_instance.ec2_instance.arn
+output "ipv6_addresses" {
+  description = "The IPv6 address assigned to the instance, if applicable"
+  value = try(
+    aws_instance.this[0].ipv6_addresses,
+    aws_instance.ignore_ami[0].ipv6_addresses,
+    aws_spot_instance_request.this[0].ipv6_addresses,
+    [],
+  )
 }
 
-output "iam_instance_profile" {
-  description = "The IAM instance profile attached to the EC2 instance."
-  value       = aws_instance.ec2_instance.iam_instance_profile
+output "tags_all" {
+  description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
+  value = try(
+    aws_instance.this[0].tags_all,
+    aws_instance.ignore_ami[0].tags_all,
+    aws_spot_instance_request.this[0].tags_all,
+    {},
+  )
 }
 
-output "instance_name" {
-  description = "The name assigned to the EC2 instance"
-  value       = aws_instance.ec2_instance.tags["Name"]
+output "spot_bid_status" {
+  description = "The current bid status of the Spot Instance Request"
+  value       = try(aws_spot_instance_request.this[0].spot_bid_status, null)
 }
 
-output "instance_type" {
-  description = "The type of the EC2 instance (e.g., t2.micro, t3.medium)"
-  value       = aws_instance.ec2_instance.instance_type
+output "spot_request_state" {
+  description = "The current request state of the Spot Instance Request"
+  value       = try(aws_spot_instance_request.this[0].spot_request_state, null)
 }
 
-output "key_name" {
-  description = "The name of the SSH key pair used to connect to the instance"
-  value       = aws_instance.ec2_instance.key_name
+output "spot_instance_id" {
+  description = "The Instance ID (if any) that is currently fulfilling the Spot Instance request"
+  value       = try(aws_spot_instance_request.this[0].spot_instance_id, null)
 }
 
-output "root_volume_size" {
-  description = "The size of the root EBS volume in GB"
-  value       = aws_instance.ec2_instance.root_block_device[0].volume_size
+output "ami" {
+  description = "AMI ID that was used to create the instance"
+  value = try(
+    aws_instance.this[0].ami,
+    aws_instance.ignore_ami[0].ami,
+    aws_spot_instance_request.this[0].ami,
+    null,
+  )
 }
 
-output "ebs_volumes" {
-  description = "List of additional EBS volumes attached to the instance"
-  value       = aws_instance.ec2_instance.ebs_block_device
+output "availability_zone" {
+  description = "The availability zone of the created instance"
+  value = try(
+    aws_instance.this[0].availability_zone,
+    aws_instance.ignore_ami[0].availability_zone,
+    aws_spot_instance_request.this[0].availability_zone,
+    null,
+  )
 }
 
-output "tags" {
-  description = "The metadata tags associated with the EC2 instance"
-  value       = aws_instance.ec2_instance.tags
+# IAM Role / Instance Profile
+
+output "iam_role_name" {
+  description = "The name of the IAM role"
+  value       = try(aws_iam_role.this[0].name, null)
+}
+
+output "iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the IAM role"
+  value       = try(aws_iam_role.this[0].arn, null)
+}
+
+output "iam_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role"
+  value       = try(aws_iam_role.this[0].unique_id, null)
+}
+
+output "iam_instance_profile_arn" {
+  description = "ARN assigned by AWS to the instance profile"
+  value       = try(aws_iam_instance_profile.this[0].arn, null)
+}
+
+output "iam_instance_profile_id" {
+  description = "Instance profile's ID"
+  value       = try(aws_iam_instance_profile.this[0].id, null)
+}
+
+output "iam_instance_profile_unique" {
+  description = "Stable and unique string identifying the IAM instance profile"
+  value       = try(aws_iam_instance_profile.this[0].unique_id, null)
+}
+
+# Block Devices
+output "root_block_device" {
+  description = "Root block device information"
+  value = try(
+    aws_instance.this[0].root_block_device,
+    aws_instance.ignore_ami[0].root_block_device,
+    aws_spot_instance_request.this[0].root_block_device,
+    null
+  )
+}
+
+output "ebs_block_device" {
+  description = "EBS block device information"
+  value = try(
+    aws_instance.this[0].ebs_block_device,
+    aws_instance.ignore_ami[0].ebs_block_device,
+    aws_spot_instance_request.this[0].ebs_block_device,
+    null
+  )
+}
+
+output "ephemeral_block_device" {
+  description = "Ephemeral block device information"
+  value = try(
+    aws_instance.this[0].ephemeral_block_device,
+    aws_instance.ignore_ami[0].ephemeral_block_device,
+    aws_spot_instance_request.this[0].ephemeral_block_device,
+    null
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,81 +1,423 @@
-# Required
-variable "ami_id" {
-  description = "The AMI ID to use for the EC2 instance."
-  type        = string
-}
-
-variable "instance_type" {
-  description = "The type of instance to start."
-  type        = string
-  default     = "t2.micro" # Optional
-}
-
-# Required
-variable "subnet_id" {
-  description = "The VPC Subnet ID to launch the instance in."
-  type        = string
-}
-
-# Required
-variable "security_group_ids" {
-  description = "A list of security group IDs to associate with the instance."
-  type        = list(string)
-}
-
-variable "key_name" {
-  description = "The key name of the Key Pair to use for the instance."
-  type        = string
-  default     = "" # Optional
-}
-
-# Required
-variable "instance_name" {
-  description = "The name tag for the EC2 instance."
-  type        = string
-}
-
-variable "root_volume_size" {
-  description = "The size of the root volume in gigabytes."
-  type        = number
-  default     = 8 # Optional
-}
-
-variable "root_volume_type" {
-  description = "The type of the root volume (e.g., gp2, gp3)."
-  type        = string
-  default     = "gp2" # Optional
-}
-
-variable "root_volume_encryption" {
-  description = "Enable encryption for the root volume."
+variable "create" {
+  description = "Whether to create an instance"
   type        = bool
-  default     = true # Optional
+  default     = true
 }
 
-variable "tags" {
-  description = "A map of tags to assign to the instance."
-  type        = map(string)
-  default     = {} # Optional
+variable "name" {
+  description = "Name to be used on EC2 instance created"
+  type        = string
+  default     = ""
+}
+
+variable "ami_ssm_parameter" {
+  description = "SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html)"
+  type        = string
+  default     = "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+}
+
+variable "ami" {
+  description = "ID of AMI to use for the instance"
+  type        = string
+  default     = null
+}
+
+variable "ignore_ami_changes" {
+  description = "Whether changes to the AMI ID changes should be ignored by Terraform. Note - changing this value will result in the replacement of the instance"
+  type        = bool
+  default     = false
+}
+
+variable "associate_public_ip_address" {
+  description = "Whether to associate a public IP address with an instance in a VPC"
+  type        = bool
+  default     = null
+}
+
+variable "maintenance_options" {
+  description = "The maintenance options for the instance"
+  type        = any
+  default     = {}
+}
+
+variable "availability_zone" {
+  description = "AZ to start the instance in"
+  type        = string
+  default     = null
+}
+
+variable "capacity_reservation_specification" {
+  description = "Describes an instance's Capacity Reservation targeting option"
+  type        = any
+  default     = {}
+}
+
+variable "cpu_credits" {
+  description = "The credit option for CPU usage (unlimited or standard)"
+  type        = string
+  default     = null
+}
+
+variable "disable_api_termination" {
+  description = "If true, enables EC2 Instance Termination Protection"
+  type        = bool
+  default     = null
+}
+
+variable "ebs_block_device" {
+  description = "Additional EBS block devices to attach to the instance"
+  type        = list(any)
+  default     = []
+}
+
+variable "ebs_optimized" {
+  description = "If true, the launched EC2 instance will be EBS-optimized"
+  type        = bool
+  default     = null
+}
+
+variable "enclave_options_enabled" {
+  description = "Whether Nitro Enclaves will be enabled on the instance. Defaults to `false`"
+  type        = bool
+  default     = null
+}
+
+variable "ephemeral_block_device" {
+  description = "Customize Ephemeral (also known as Instance Store) volumes on the instance"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "get_password_data" {
+  description = "If true, wait for password data to become available and retrieve it"
+  type        = bool
+  default     = null
+}
+
+variable "hibernation" {
+  description = "If true, the launched EC2 instance will support hibernation"
+  type        = bool
+  default     = null
+}
+
+variable "host_id" {
+  description = "ID of a dedicated host that the instance will be assigned to. Use when an instance is to be launched on a specific dedicated host"
+  type        = string
+  default     = null
 }
 
 variable "iam_instance_profile" {
-  description = "The IAM instance profile to attach to the EC2 instance."
+  description = "IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile"
   type        = string
+  default     = null
 }
 
-variable "ebs_volumes" {
-  description = "A list of additional EBS volumes to attach to the instance."
-  type = list(object({
-    device_name = string
-    volume_size = number
-    volume_type = string
-    encrypted   = bool
-  }))
-  default = [] # Optional
+variable "instance_initiated_shutdown_behavior" {
+  description = "Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior
+  type        = string
+  default     = null
 }
 
-variable "enable_imdsv2" {
-  description = "Enable IMDSv2 for the EC2 instance."
+variable "instance_type" {
+  description = "The type of instance to start"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "instance_tags" {
+  description = "Additional tags for the instance"
+  type        = map(string)
+  default     = {}
+}
+
+variable "ipv6_address_count" {
+  description = "A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet"
+  type        = number
+  default     = null
+}
+
+variable "ipv6_addresses" {
+  description = "Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface"
+  type        = list(string)
+  default     = null
+}
+
+variable "key_name" {
+  description = "Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource"
+  type        = string
+  default     = null
+}
+
+variable "launch_template" {
+  description = "Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template"
+  type        = map(string)
+  default     = {}
+}
+
+variable "metadata_options" {
+  description = "Customize the metadata options of the instance"
+  type        = map(string)
+  default = {
+    "http_endpoint"               = "enabled"
+    "http_put_response_hop_limit" = 1
+    "http_tokens"                 = "required"
+  }
+}
+
+variable "monitoring" {
+  description = "If true, the launched EC2 instance will have detailed monitoring enabled"
   type        = bool
-  default     = true # Optional
+  default     = null
+}
+
+variable "network_interface" {
+  description = "Customize network interfaces to be attached at instance boot time"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "private_dns_name_options" {
+  description = "Customize the private DNS name options of the instance"
+  type        = map(string)
+  default     = {}
+}
+
+variable "placement_group" {
+  description = "The Placement Group to start the instance in"
+  type        = string
+  default     = null
+}
+
+variable "private_ip" {
+  description = "Private IP address to associate with the instance in a VPC"
+  type        = string
+  default     = null
+}
+
+variable "root_block_device" {
+  description = "Customize details about the root block device of the instance. See Block Devices below for details"
+  type        = list(any)
+  default     = []
+}
+
+variable "secondary_private_ips" {
+  description = "A list of secondary private IPv4 addresses to assign to the instance's primary network interface (eth0) in a VPC. Can only be assigned to the primary network interface (eth0) attached at instance creation, not a pre-existing network interface i.e. referenced in a `network_interface block`"
+  type        = list(string)
+  default     = null
+}
+
+variable "source_dest_check" {
+  description = "Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs"
+  type        = bool
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "The VPC Subnet ID to launch in"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tenancy" {
+  description = "The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host"
+  type        = string
+  default     = null
+}
+
+variable "user_data" {
+  description = "The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user_data_base64 instead"
+  type        = string
+  default     = null
+}
+
+variable "user_data_base64" {
+  description = "Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption"
+  type        = string
+  default     = null
+}
+
+variable "user_data_replace_on_change" {
+  description = "When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set"
+  type        = bool
+  default     = null
+}
+
+variable "volume_tags" {
+  description = "A mapping of tags to assign to the devices created by the instance at launch time"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_volume_tags" {
+  description = "Whether to enable volume tags (if enabled it conflicts with root_block_device tags)"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of security group IDs to associate with"
+  type        = list(string)
+  default     = null
+}
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting EC2 instance resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cpu_options" {
+  description = "Defines CPU options to apply to the instance at launch time."
+  type        = any
+  default     = {}
+}
+
+variable "cpu_core_count" {
+  description = "Sets the number of CPU cores for an instance" # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
+  type        = number
+  default     = null
+}
+
+variable "cpu_threads_per_core" {
+  description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)"
+  type        = number
+  default     = null
+}
+
+# Spot instance request
+variable "create_spot_instance" {
+  description = "Depicts if the instance is a spot instance"
+  type        = bool
+  default     = false
+}
+
+variable "spot_price" {
+  description = "The maximum price to request on the spot market. Defaults to on-demand price"
+  type        = string
+  default     = null
+}
+
+variable "spot_wait_for_fulfillment" {
+  description = "If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached"
+  type        = bool
+  default     = null
+}
+
+variable "spot_type" {
+  description = "If set to one-time, after the instance is terminated, the spot request will be closed. Default `persistent`"
+  type        = string
+  default     = null
+}
+
+variable "spot_launch_group" {
+  description = "A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually"
+  type        = string
+  default     = null
+}
+
+variable "spot_block_duration_minutes" {
+  description = "The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)"
+  type        = number
+  default     = null
+}
+
+variable "spot_instance_interruption_behavior" {
+  description = "Indicates Spot instance behavior when it is interrupted. Valid values are `terminate`, `stop`, or `hibernate`"
+  type        = string
+  default     = null
+}
+
+variable "spot_valid_until" {
+  description = "The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+  type        = string
+  default     = null
+}
+
+variable "spot_valid_from" {
+  description = "The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+  type        = string
+  default     = null
+}
+
+variable "disable_api_stop" {
+  description = "If true, enables EC2 Instance Stop Protection"
+  type        = bool
+  default     = null
+
+}
+
+# IAM Role / Instance Profile
+
+variable "create_iam_instance_profile" {
+  description = "Determines whether an IAM instance profile is created or to use an existing IAM instance profile"
+  type        = bool
+  default     = false
+}
+
+variable "iam_role_name" {
+  description = "Name to use on IAM role created"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_use_name_prefix" {
+  description = "Determines whether the IAM role name (`iam_role_name` or `name`) is used as a prefix"
+  type        = bool
+  default     = true
+}
+
+variable "iam_role_path" {
+  description = "IAM role path"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_description" {
+  description = "Description of the role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_permissions_boundary" {
+  description = "ARN of the policy that is used to set the permissions boundary for the IAM role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_policies" {
+  description = "Policies attached to the IAM role"
+  type        = map(string)
+  default     = {}
+}
+
+variable "iam_role_tags" {
+  description = "A map of additional tags to add to the IAM role/profile created"
+  type        = map(string)
+  default     = {}
+}
+
+# Elastic IP
+
+variable "create_eip" {
+  description = "Determines whether a public EIP will be created and associated with the instance."
+  type        = bool
+  default     = false
+}
+
+variable "eip_domain" {
+  description = "Indicates if this EIP is for use in VPC"
+  type        = string
+  default     = "vpc"
+}
+
+variable "eip_tags" {
+  description = "A map of additional tags to add to the eip"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
This pull request complete refactor of the EC2 module to reflect changes in the module's source, input variables, outputs, and documentation structure. It transitions the module to use a more feature-rich and community-maintained Terraform module, adds new input variables and outputs, and includes additional documentation sections.

### Module Source and Configuration Updates:
* Updated the module source to `sudo-terraform-aws-modules/ec2-instance/aws` and adjusted example usage to reflect the new module's parameters, such as `name`, `key_name`, `monitoring`, `vpc_security_group_ids`, and `subnet_id`.

### Input and Output Variables:
* Replaced the previous input variable table with a new, expanded set of input variables, introducing parameters for advanced configurations like `ami_ssm_parameter`, `cpu_options`, `metadata_options`, and `ebs_block_device`.
* Updated the outputs section to include a comprehensive list of outputs such as `ami`, `arn`, `root_block_device`, and `spot_instance_id`, among others.

### Documentation Enhancements:
* Added an "Authors" section crediting the maintainers of the module and a "License" section specifying the Apache 2 license.